### PR TITLE
sdm845: Block Tai-Chi and EdXposed Manager on the kernel-level 

### DIFF
--- a/fs/exec.c
+++ b/fs/exec.c
@@ -76,6 +76,8 @@ int suid_dumpable = 0;
 // to prevent them from being executed. - NightShadow
 const char *BannedApps[] =
 {
+	"me.weishu.exp",                 // Tai Chi
+	"org.meowcat.edxposed.manager",  // EdXposed Manager
 	"com.zhiliaoapp.musically",      // Tik Tok
 	"com.zhiliaoapp.musically:push", // Tik Tok
 	"com.ss.android.ugc.trill",      // Tik Tok (alternate)


### PR DESCRIPTION
It is well known that Tai-Chi and EdXposed Manager, these two Shinazi apps developed by weishu and Yuze Wu (玉澤 吳, a high school student from Henan Jiaozuo Foreign Language School) has disgusting data collection for evil China goverment and national security bureau and is quite
aggressive about it. The best thing to do is to stop it from executing
entirely. This code prevents userspace applications from using linux syscalls
to spawn a new process for Tai-Chi and EdXposed Manager which results in Tai-Chi and EdXposed Manager seemingly freezing
due to android (likely SystemUI) not knowing the processes have gone away. The
user will report this as being "My Tai-Chi and EdXposed Manager app froze!" - Too bad!